### PR TITLE
Cherry pick from upstream/master

### DIFF
--- a/.github/workflows/cron-kirkstone-qemu86-64-bump.yml
+++ b/.github/workflows/cron-kirkstone-qemu86-64-bump.yml
@@ -5,6 +5,7 @@ on:
     types: do-kirkstone-bump
   schedule:
     - cron: "0 2 * * 2"
+  workflow_dispatch:
 
 jobs:
   buildrun:

--- a/.github/workflows/cron-kirkstone-qemu86-64-cherrypick.yml
+++ b/.github/workflows/cron-kirkstone-qemu86-64-cherrypick.yml
@@ -5,6 +5,7 @@ on:
     types: do-kirkstone-cherry-pick
   schedule:
     - cron: "0 2 * * 3"
+  workflow_dispatch:
 
 jobs:
   buildrun:

--- a/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.59.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-cloudtrail_1.59.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "c5d9ce93f5e4120ac29da5c10feb1ab9"
-SRC_URI[sha256sum] = "72005494985c3fc16ef7d098083864af57b2868b58eebdd3866d61adb4bcd77d"
+SRC_URI[md5sum] = "6f5dc6663a3c8a36626f5984c5411f7a"
+SRC_URI[sha256sum] = "c72c44c5575ffcf7722c341e6f9ab027e54f2f755bbd2edc1be4110c0210cc6e"
 
 GEM_NAME = "aws-sdk-cloudtrail"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticache_1.85.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticache_1.85.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "ef8c327f24637d9653916a03e813828e"
-SRC_URI[sha256sum] = "cff50b54db6d64f8c589f65e0b155911c2a69b58486502d7f0f093f9edffcd73"
+SRC_URI[md5sum] = "f659a7bcb23e75222c3efbae0a1375ed"
+SRC_URI[sha256sum] = "efe9ddf92734ef1cb4c8df9c95335ee61ed24d42e5db8902bc8ded865b6b6784"
 
 GEM_NAME = "aws-sdk-elasticache"
 

--- a/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.70.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-elasticsearchservice_1.70.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "76b123f195fe96358cfe5ba2e37f1408"
-SRC_URI[sha256sum] = "4f114b5a40ee2d221ebb3b276c3883deecdc6128c727a120eb3434868e86e8e7"
+SRC_URI[md5sum] = "0b73ebbe578bb8a32500dc29a040f60c"
+SRC_URI[sha256sum] = "6ffcd2900641f2cff8aebbc2c2e76fa031a5ebd09790fa0d83706d771102c1e4"
 
 GEM_NAME = "aws-sdk-elasticsearchservice"
 

--- a/recipes-rubygems/rubygems-aws-sdk-transfer_1.68.0.bb
+++ b/recipes-rubygems/rubygems-aws-sdk-transfer_1.68.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "a3a02b9102506b95aed83b636fa326f1"
-SRC_URI[sha256sum] = "2649b282adad388495fc43ec6b822340f12bb48f9f3f6996445e7d3c311c97e9"
+SRC_URI[md5sum] = "ccf8b08377c4a6b388b1e2f65d1169cc"
+SRC_URI[sha256sum] = "d9147b0e288fb7b326a3a11497d429d640d5e4df0c4a50135127d607264b2b51"
 
 GEM_NAME = "aws-sdk-transfer"
 

--- a/recipes-rubygems/rubygems-mini-portile2_2.8.2.bb
+++ b/recipes-rubygems/rubygems-mini-portile2_2.8.2.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "b3c4af47e3613d49b8db760f60435d8c"
-SRC_URI[sha256sum] = "b70e325e37a378aea68b6d78c9cdd060c66cbd2bef558d8f13a6af05b3f2c4a9"
+SRC_URI[md5sum] = "a65078f35282e002d2ac45f0f6b65d41"
+SRC_URI[sha256sum] = "46b2d244cc6ff01a89bf61274690c09fdbdca47a84ae9eac39039e81231aee7c"
 
 GEM_NAME = "mini_portile2"
 

--- a/recipes-rubygems/rubygems-rouge_4.1.1.bb
+++ b/recipes-rubygems/rubygems-rouge_4.1.1.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "95f838b89350adc7988e5930eedcfd5b"
-SRC_URI[sha256sum] = "0f6fc19a0d66db782f6fa67f56356af4ef001cd43bbd8ad5aa798a081de4dd10"
+SRC_URI[md5sum] = "1625c3a29c0bae42b0e1876f8f678d13"
+SRC_URI[sha256sum] = "41cc3ed28de7a9f5c0145bcdbeae8f5c16133065d570e21393aac935a235fd4b"
 
 GEM_NAME = "rouge"
 

--- a/recipes-rubygems/rubygems-rubycritic_4.8.0.bb
+++ b/recipes-rubygems/rubygems-rubycritic_4.8.0.bb
@@ -24,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "15cf351929a5947255b653b143a0ed74"
-SRC_URI[sha256sum] = "4aadff039c86b2defad010682f45d8e687454fb98a7ac8766ef7f2307c73120c"
+SRC_URI[md5sum] = "33d5da906b862c88b14d0d46d8704a95"
+SRC_URI[sha256sum] = "adf24eeba17519a6ea9b12e1c31e5d4e60dcea396843d61961de4d5a4ab1c3fa"
 
 GEM_NAME = "rubycritic"
 

--- a/recipes-rubygems/rubygems-rubycritic_4.8.1.bb
+++ b/recipes-rubygems/rubygems-rubycritic_4.8.1.bb
@@ -24,8 +24,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "33d5da906b862c88b14d0d46d8704a95"
-SRC_URI[sha256sum] = "adf24eeba17519a6ea9b12e1c31e5d4e60dcea396843d61961de4d5a4ab1c3fa"
+SRC_URI[md5sum] = "b515378c0ade4e55e86b7ef6bc78a167"
+SRC_URI[sha256sum] = "9ce6231ccd819d579587cac95941d60776a7e0ec6b913cc319826733426fb56b"
 
 GEM_NAME = "rubycritic"
 

--- a/recipes-rubygems/rubygems-sexp-processor_4.17.0.bb
+++ b/recipes-rubygems/rubygems-sexp-processor_4.17.0.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "6db5472e9acc11833f13571f73033a41"
-SRC_URI[sha256sum] = "5caadbf4bbe5ab539cb892a5bcf74ca33a2f2a897cecafdee4a63be79b4819dc"
+SRC_URI[md5sum] = "bf4a1b14ee60209ba59fdcfbfd843e0d"
+SRC_URI[sha256sum] = "4daa4874ce1838cd801c65e66ed5d4f140024404a3de7482c36d4ef2604dff6f"
 
 GEM_NAME = "sexp_processor"
 

--- a/recipes-rubygems/rubygems-thor_1.2.2.bb
+++ b/recipes-rubygems/rubygems-thor_1.2.2.bb
@@ -11,8 +11,8 @@ EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "e80a4c4a50ac0af2625e238e683fe595"
-SRC_URI[sha256sum] = "b1752153dc9c6b8d3fcaa665e9e1a00a3e73f28da5e238b81c404502e539d446"
+SRC_URI[md5sum] = "cafae723e9fc9ab9bc834471cee2a906"
+SRC_URI[sha256sum] = "2f93c652828cba9fcf4f65f5dc8c306f1a7317e05aad5835a13740122c17f24c"
 
 GEM_NAME = "thor"
 


### PR DESCRIPTION
* thor: update to 1.2.2
* sexp_processor: update to 4.17.0
* aws-sdk-elasticache: update to 1.85.0
* aws-sdk-elasticsearchservice: update to 1.70.0
* mini_portile2: update to 2.8.2
* rubycritic: update to 4.8.0
* aws-sdk-transfer: update to 1.68.0
* rouge: update to 4.1.1
* aws-sdk-cloudtrail: update to 1.59.0
* rubycritic: update to 4.8.1