### PR TITLE
Cherry pick from upstream/master

### DIFF
--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.15.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.15.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cd370c28fc74d1d67e9abd6c3f8bfad1"
-SRC_URI[sha256sum] = "a2236bee42f3150b83a255f4b6024761d80a8126b69d208855729c9e26f42b3d"
+SRC_URI[md5sum] = "95618e017ddeaae9a6cfacd92fcc79a4"
+SRC_URI[sha256sum] = "7d4214274c1dfbb83f6f51ba3ac5226a9c9b4433b3b1858a1710761bc30dfd30"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-generator_0.13.1.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.13.1.bb
@@ -19,8 +19,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fc7ca18a33b00441fbdcd705d46de8ed"
-SRC_URI[sha256sum] = "b657528b59b27b6c14adf08182dfcb5729994c03eacbe5dedf093971701615e1"
+SRC_URI[md5sum] = "ce0409af50e2c9140f4d0936fe449641"
+SRC_URI[sha256sum] = "93db6a895a4eee93a2dd88c8a095149a0969dc2b0d94f88045811c59871a26b2"
 
 GEM_NAME = "google-apis-generator"
 

--- a/recipes-rubygems/rubygems-train-aws_0.2.24.bb
+++ b/recipes-rubygems/rubygems-train-aws_0.2.24.bb
@@ -98,6 +98,10 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+do_configure:prepend() {
+    sed -i 's#"= 1.102.0"#">= 1.102.0"#g' ${GEM_SPEC_FILE}
+}
+
 RDEPENDS:${PN}:class-target += "\
     rubygems-aws-sdk-alexaforbusiness \
     rubygems-aws-sdk-amplify \


### PR DESCRIPTION
* google-apis-discovery_v1: update to 0.15.0
* google-apis-generator: update to 0.13.1
* train-aws: lift hard version pinning