### PR TITLE
Cherry pick from upstream/master

### DIFF
--- a/recipes-rubygems/rubygems-diff-lcs_1.5.1.bb
+++ b/recipes-rubygems/rubygems-diff-lcs_1.5.1.bb
@@ -4,15 +4,15 @@ DESCRIPTION = "Diff::LCS computes the difference between two Enumerable sequence
 HOMEPAGE = "https://github.com/halostatue/diff-lcs"
 
 LICENSE = "MIT & Artistic-2.0 & GPL-2.0-or-later"
-LIC_FILES_CHKSUM = "file://License.md;md5=debd9dff6792a920e1ca0ee909e1926a"
+LIC_FILES_CHKSUM = "file://License.md;md5=ea4648088e1ee6748049f22fe24901ea"
 
 EXTRA_DEPENDS:append = " "
 EXTRA_RDEPENDS:append = " "
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "7e80da0d376d61914f08f9ea9aedc46d"
-SRC_URI[sha256sum] = "49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67"
+SRC_URI[md5sum] = "f4f1d50eed7496f7f32b09c9e81a5845"
+SRC_URI[sha256sum] = "273223dfb40685548436d32b4733aa67351769c7dea621da7d9dd4813e63ddfe"
 
 GEM_NAME = "diff-lcs"
 

--- a/recipes-rubygems/rubygems-google-apis-discovery-v1_0.15.0.bb
+++ b/recipes-rubygems/rubygems-google-apis-discovery-v1_0.15.0.bb
@@ -15,8 +15,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "cd370c28fc74d1d67e9abd6c3f8bfad1"
-SRC_URI[sha256sum] = "a2236bee42f3150b83a255f4b6024761d80a8126b69d208855729c9e26f42b3d"
+SRC_URI[md5sum] = "95618e017ddeaae9a6cfacd92fcc79a4"
+SRC_URI[sha256sum] = "7d4214274c1dfbb83f6f51ba3ac5226a9c9b4433b3b1858a1710761bc30dfd30"
 
 GEM_NAME = "google-apis-discovery_v1"
 

--- a/recipes-rubygems/rubygems-google-apis-generator_0.13.1.bb
+++ b/recipes-rubygems/rubygems-google-apis-generator_0.13.1.bb
@@ -19,8 +19,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "fc7ca18a33b00441fbdcd705d46de8ed"
-SRC_URI[sha256sum] = "b657528b59b27b6c14adf08182dfcb5729994c03eacbe5dedf093971701615e1"
+SRC_URI[md5sum] = "ce0409af50e2c9140f4d0936fe449641"
+SRC_URI[sha256sum] = "93db6a895a4eee93a2dd88c8a095149a0969dc2b0d94f88045811c59871a26b2"
 
 GEM_NAME = "google-apis-generator"
 

--- a/recipes-rubygems/rubygems-train-aws_0.2.24.bb
+++ b/recipes-rubygems/rubygems-train-aws_0.2.24.bb
@@ -98,6 +98,10 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+do_configure:prepend() {
+    sed -i 's#"= 1.102.0"#">= 1.102.0"#g' ${GEM_SPEC_FILE}
+}
+
 RDEPENDS:${PN}:class-target += "\
     rubygems-aws-sdk-alexaforbusiness \
     rubygems-aws-sdk-amplify \


### PR DESCRIPTION
* google-apis-discovery_v1: update to 0.15.0
* google-apis-generator: update to 0.13.1
* train-aws: lift hard version pinning
* diff-lcs: update to 1.5.1