### PR TITLE
Cherry pick from upstream/master

### DIFF
--- a/recipes-rubygems/rubygems-faraday-excon_2.2.0.bb
+++ b/recipes-rubygems/rubygems-faraday-excon_2.2.0.bb
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 SUMMARY = "RubyGem: faraday-excon"
 DESCRIPTION = "Faraday adapter for Excon"
-HOMEPAGE = "https://github.com/lostisland/faraday-excon"
+HOMEPAGE = "https://github.com/excon/faraday-excon"
 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=20830660ee48a0c845a62aad77c18f4a"
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "877a1b9f62a6fd5e6efda124fa842c59"
-SRC_URI[sha256sum] = "d487bad1c13342457fbcf79d0abc70f8d6d07280c0276bba716122e4a79eebfa"
+SRC_URI[md5sum] = "a0dbdba8ec2a5db859d0bd21690b6ad7"
+SRC_URI[sha256sum] = "46956f67aa7a402472a23749b158b9d5d3b54bfc73789167126c84aacc786c0e"
 
 GEM_NAME = "faraday-excon"
 

--- a/recipes-rubygems/rubygems-faraday-net-http-persistent_2.2.0.bb
+++ b/recipes-rubygems/rubygems-faraday-net-http-persistent_2.2.0.bb
@@ -16,8 +16,8 @@ DEPENDS:class-native += "\
 
 GEM_INSTALL_FLAGS:append = " "
 
-SRC_URI[md5sum] = "dae28ee18572c50428bb3682a5c11f53"
-SRC_URI[sha256sum] = "b41720b13f56dae77114d9de54baef2d76d0b06ab40d695b2a98e254b56ade0b"
+SRC_URI[md5sum] = "24e857e5ad7f0a281605a967d97e2962"
+SRC_URI[sha256sum] = "aebc84f5166cce77a5a9e05e14873326ee0c25e5611e22b8df99c1fbfd23f60e"
 
 GEM_NAME = "faraday-net_http_persistent"
 

--- a/recipes-rubygems/rubygems-simplecov-html_0.13.1.bb
+++ b/recipes-rubygems/rubygems-simplecov-html_0.13.1.bb
@@ -6,8 +6,13 @@ HOMEPAGE = "https://github.com/simplecov-ruby/simplecov-html"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=23973b4bd84f8a5e081dd23bb739394d"
 
-SRC_URI[md5sum] = "2f0241c3a12f5af62bd84c1f1914a722"
-SRC_URI[sha256sum] = "4b1aad33259ffba8b29c6876c12db70e5750cb9df829486e4c6e5da4fa0aa07b"
+EXTRA_DEPENDS:append = " "
+EXTRA_RDEPENDS:append = " "
+
+GEM_INSTALL_FLAGS:append = " "
+
+SRC_URI[md5sum] = "9dfe06e945a254dae1d3fff7da03e1dc"
+SRC_URI[sha256sum] = "5dab0b7ee612e60e9887ad57693832fdf4695b4c0c859eaea5f95c18791ef10b"
 
 GEM_NAME = "simplecov-html"
 


### PR DESCRIPTION
* simplecov-html: update to 0.13.1
* faraday-net_http_persistent: update to 2.2.0
* faraday-excon: update to 2.2.0