### PR TITLE
Cherry pick from upstream/master

### DIFF
--- a/recipes-rubygems/rubygems-bcrypt-pbkdf_1.1.0.bb
+++ b/recipes-rubygems/rubygems-bcrypt-pbkdf_1.1.0.bb
@@ -17,4 +17,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-bson_4.15.0.bb
+++ b/recipes-rubygems/rubygems-bson_4.15.0.bb
@@ -20,4 +20,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-ed25519_1.3.0.bb
+++ b/recipes-rubygems/rubygems-ed25519_1.3.0.bb
@@ -20,4 +20,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-eventmachine_1.2.7.bb
+++ b/recipes-rubygems/rubygems-eventmachine_1.2.7.bb
@@ -22,4 +22,7 @@ do_install:append() {
     rm -f ${D}/${libdir}/ruby/gems/3.0.0/gems/eventmachine-${PV}/lib/jeventmachine.rb
 }
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-ffi-yajl_2.4.0.bb
+++ b/recipes-rubygems/rubygems-ffi-yajl_2.4.0.bb
@@ -39,4 +39,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-libyajl2 \
 "
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-ffi_1.15.5.bb
+++ b/recipes-rubygems/rubygems-ffi_1.15.5.bb
@@ -25,4 +25,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-http-parser.rb_0.8.0.bb
+++ b/recipes-rubygems/rubygems-http-parser.rb_0.8.0.bb
@@ -20,4 +20,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-json_2.5.1.bb
+++ b/recipes-rubygems/rubygems-json_2.5.1.bb
@@ -15,4 +15,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-libyajl2_2.1.0.bb
+++ b/recipes-rubygems/rubygems-libyajl2_2.1.0.bb
@@ -19,4 +19,8 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+INSANE_SKIP:${PN}-dev += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-nokogiri_1.14.2.bb
+++ b/recipes-rubygems/rubygems-nokogiri_1.14.2.bb
@@ -38,6 +38,9 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-racc \
 "
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 INSANE_SKIP:${PN}-dev += "staticdev"
 
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-patron_0.13.3.bb
+++ b/recipes-rubygems/rubygems-patron_0.13.3.bb
@@ -20,4 +20,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-sassc_2.4.0.bb
+++ b/recipes-rubygems/rubygems-sassc_2.4.0.bb
@@ -29,4 +29,7 @@ RDEPENDS:${PN}:class-target += "\
     rubygems-ffi \
 "
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-unf-ext_0.0.8.2.bb
+++ b/recipes-rubygems/rubygems-unf-ext_0.0.8.2.bb
@@ -20,4 +20,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"

--- a/recipes-rubygems/rubygems-yajl-ruby_1.4.3.bb
+++ b/recipes-rubygems/rubygems-yajl-ruby_1.4.3.bb
@@ -20,4 +20,7 @@ inherit rubygems
 inherit rubygentest
 inherit pkgconfig
 
+# The vendored library is causing some rpath issues
+INSANE_SKIP:${PN} += "rpaths"
+
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
* rubygems-libyayl2: ignore rpaths issues
* rubygems-ffi: ignore rpaths issues
* rubygems-eventmachine: ignore rpaths issues
* rubygems-json: ignore rpaths issues
* rubygems-ffi-yajl: ignore rpaths issues
* rubygems-http-parser: ignore rpaths issues
* rubygems-unf-ext: ignore rpath issues
* rubygems-yajl-ruby: ignore rpaths issues
* rubygems-bson: ignore rpath issues
* rubygems-patron: ignore rpath issues
* rubygems-bcrypt-pbkdf: ignore rpath issues
* rubygems-ed25519: ignore rpath issues
* rubygems-sassc: ignore rpath issues
* rubygems-nokogiri: ignore rpath issues